### PR TITLE
Add support for proxy_read_timeout

### DIFF
--- a/configs/https_proxy.conf
+++ b/configs/https_proxy.conf
@@ -17,5 +17,6 @@
             proxy_set_header    X-Real-IP $remote_addr;
             proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header    X-Forwarded-Proto $scheme;
+            proxy_read_timeout  ${READ_TIMEOUT};
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       TEST_SERVER_NAME: "test.example.org"
       TEST_BACKEND_SERVER: "http://backend/"
       TEST_HSTS_MAX_AGE: "800"
+      TEST_READ_TIMEOUT: "5s"
       TEST_SSL_CERTIFICATE: |-
         -----BEGIN CERTIFICATE-----
         MIIDCTCCAfGgAwIBAgIJALw8149pyAWJMA0GCSqGSIb3DQEBBQUAMBsxGTAXBgNV
@@ -116,6 +117,7 @@ services:
       TEST3_FRONTEND_URL: "/hello"
       TEST3_BACKEND_SERVER: "http://backend/"
       TEST3_HSTS_MAX_AGE: "800"
+      TEST3_READ_TIMEOUT: "20s"
       TEST3_SSL_CERTIFICATE: |-
         -----BEGIN CERTIFICATE-----
         MIIDCTCCAfGgAwIBAgIJALw8149pyAWJMA0GCSqGSIb3DQEBBQUAMBsxGTAXBgNV

--- a/test.sh
+++ b/test.sh
@@ -60,8 +60,20 @@ test_frontend_url() {
     test "$(curl -k -s --resolve test3.example.org:33443:127.0.0.1 --fail https://test3.example.org:33443/hello/request_headers.php | grep '^Host:.*$' | head -n1)" == $'Host: test3.example.org'
 }
 
+test_timeout_after_5_seconds_on_test_example_org(){
+    ! curl --fail --head -s -H 'Host: test.example.org' -k \
+        https://127.0.0.1:33443/timeout_10s.php > /dev/null
+}
+
+test_don_t_timeout_after_10_seconds_on_test3_example_org(){
+    curl --fail -s -H 'Host: test3.example.org' -k \
+        https://127.0.0.1:33443/hello/timeout_10s.php > /dev/null
+}
+
 curl -s --fail -k https://127.0.0.1:33443/ > /dev/null
 
+test_timeout_after_5_seconds_on_test_example_org
+test_don_t_timeout_after_10_seconds_on_test3_example_org
 test_http_redirects
 test_hsts
 test_x_real_ip

--- a/tests/php_backend/timeout_10s.php
+++ b/tests/php_backend/timeout_10s.php
@@ -1,0 +1,7 @@
+<?php
+header( 'Content-Type: text/plain' );
+
+sleep(10);
+
+echo "Good!"
+?>


### PR DESCRIPTION
By default, proxy_read_timeout might be to low.  It is now possible to
define this value via an environment variable associated to the site.

Example:

    services:
      proxy:
        image: nginx-sni-proxy
        build: .
        environment:
          SITES: "some_site"
          some_site_READ_TIMEOUT: "5s"
          [...]

Note: The default value is 120s.